### PR TITLE
Update example to include explicit mapper for Delayed::Job

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ HireFire::Resource.configure do |config|
   end
 
   config.dyno(:dj_worker) do
-    HireFire::Macro::Delayed::Job.queue
+    HireFire::Macro::Delayed::Job.queue(mapper: :active_record)
   end
 end
 ```


### PR DESCRIPTION
Changed as of https://github.com/meskyanichi/hirefire-resource/commit/895be2dfcb59e017e352216f84013eccaf23e204#diff-2502e98b7eb8903d6012429ca63afcf4
