### PR TITLE
fix QueueClassic integration to work with QC3

### DIFF
--- a/lib/hirefire/macro/qc.rb
+++ b/lib/hirefire/macro/qc.rb
@@ -16,7 +16,7 @@ module HireFire
       # @return [Integer] the number of jobs in the queue(s).
       #
       def queue(queue = "default")
-        ::QC::Worker.new(:q_name => queue.to_s).queue.count
+        ::QC::Queue.new(queue).count
       end
     end
   end


### PR DESCRIPTION
QueueClassic 3 has been in the work for a while and is now getting closer to release and some people even run it in production. This is fixing hirefire-resource to work well with QC3 and it should also work with 2.2.3 which is the latest stable release.

QC::Queue as of 2.2.3: https://github.com/ryandotsmith/queue_classic/blob/v2.2.3/lib/queue_classic/queue.rb

Thanks!
