### PR TITLE
Insert HireFire as first in middleware stack

### DIFF
--- a/lib/hirefire/railtie.rb
+++ b/lib/hirefire/railtie.rb
@@ -3,7 +3,7 @@
 module HireFire
   class Railtie < ::Rails::Railtie
     initializer "hirefire.add_middleware" do |app|
-      app.config.middleware.insert_before "Rack::ETag", "HireFire::Middleware"
+      app.config.middleware.insert 0, "HireFire::Middleware"
     end
   end
 end


### PR DESCRIPTION
This fixes any issues with `Rack::ETag` being above `HireFire::Middleware` in the stack.
